### PR TITLE
feat: add comprehensive search functionality (Issue #5)

### DIFF
--- a/src/Contracts/SpotifyClientInterface.php
+++ b/src/Contracts/SpotifyClientInterface.php
@@ -8,6 +8,7 @@ use Jordanpartridge\SpotifyClient\Resources\AlbumsResource;
 use Jordanpartridge\SpotifyClient\Resources\ArtistsResource;
 use Jordanpartridge\SpotifyClient\Resources\PlayerResource;
 use Jordanpartridge\SpotifyClient\Resources\PlaylistsResource;
+use Jordanpartridge\SpotifyClient\Resources\SearchResource;
 use Jordanpartridge\SpotifyClient\Resources\TracksResource;
 use Jordanpartridge\SpotifyClient\Resources\UsersResource;
 
@@ -24,4 +25,6 @@ interface SpotifyClientInterface
     public function users(): UsersResource;
 
     public function player(): PlayerResource;
+
+    public function search(): SearchResource;
 }

--- a/src/Requests/Search/SearchAlbumsRequest.php
+++ b/src/Requests/Search/SearchAlbumsRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jordanpartridge\SpotifyClient\Requests\Search;
+
+class SearchAlbumsRequest extends SearchRequest
+{
+    public function __construct(
+        string $query,
+        ?string $market = null,
+        int $limit = 20,
+        int $offset = 0,
+        bool $includeExternal = false
+    ) {
+        parent::__construct(
+            query: $query,
+            types: ['album'],
+            market: $market,
+            limit: $limit,
+            offset: $offset,
+            includeExternal: $includeExternal
+        );
+    }
+}

--- a/src/Requests/Search/SearchAllRequest.php
+++ b/src/Requests/Search/SearchAllRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jordanpartridge\SpotifyClient\Requests\Search;
+
+class SearchAllRequest extends SearchRequest
+{
+    public function __construct(
+        string $query,
+        ?string $market = null,
+        int $limit = 20,
+        int $offset = 0,
+        bool $includeExternal = false
+    ) {
+        parent::__construct(
+            query: $query,
+            types: ['album', 'artist', 'playlist', 'track'],
+            market: $market,
+            limit: $limit,
+            offset: $offset,
+            includeExternal: $includeExternal
+        );
+    }
+}

--- a/src/Requests/Search/SearchArtistsRequest.php
+++ b/src/Requests/Search/SearchArtistsRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jordanpartridge\SpotifyClient\Requests\Search;
+
+class SearchArtistsRequest extends SearchRequest
+{
+    public function __construct(
+        string $query,
+        ?string $market = null,
+        int $limit = 20,
+        int $offset = 0,
+        bool $includeExternal = false
+    ) {
+        parent::__construct(
+            query: $query,
+            types: ['artist'],
+            market: $market,
+            limit: $limit,
+            offset: $offset,
+            includeExternal: $includeExternal
+        );
+    }
+}

--- a/src/Requests/Search/SearchPlaylistsRequest.php
+++ b/src/Requests/Search/SearchPlaylistsRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jordanpartridge\SpotifyClient\Requests\Search;
+
+class SearchPlaylistsRequest extends SearchRequest
+{
+    public function __construct(
+        string $query,
+        ?string $market = null,
+        int $limit = 20,
+        int $offset = 0,
+        bool $includeExternal = false
+    ) {
+        parent::__construct(
+            query: $query,
+            types: ['playlist'],
+            market: $market,
+            limit: $limit,
+            offset: $offset,
+            includeExternal: $includeExternal
+        );
+    }
+}

--- a/src/Requests/Search/SearchRequest.php
+++ b/src/Requests/Search/SearchRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jordanpartridge\SpotifyClient\Requests\Search;
+
+use Jordanpartridge\SpotifyClient\Requests\BaseRequest;
+use Saloon\Enums\Method;
+
+class SearchRequest extends BaseRequest
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        private readonly string $query,
+        private readonly array $types,
+        private readonly ?string $market = null,
+        private readonly int $limit = 20,
+        private readonly int $offset = 0,
+        private readonly bool $includeExternal = false
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/search';
+    }
+
+    protected function defaultQuery(): array
+    {
+        $query = [
+            'q' => $this->query,
+            'type' => implode(',', $this->types),
+            'limit' => $this->limit,
+            'offset' => $this->offset,
+        ];
+
+        if ($this->market) {
+            $query['market'] = $this->market;
+        }
+
+        if ($this->includeExternal) {
+            $query['include_external'] = 'audio';
+        }
+
+        return $query;
+    }
+}

--- a/src/Requests/Search/SearchTracksRequest.php
+++ b/src/Requests/Search/SearchTracksRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jordanpartridge\SpotifyClient\Requests\Search;
+
+class SearchTracksRequest extends SearchRequest
+{
+    public function __construct(
+        string $query,
+        ?string $market = null,
+        int $limit = 20,
+        int $offset = 0,
+        bool $includeExternal = false
+    ) {
+        parent::__construct(
+            query: $query,
+            types: ['track'],
+            market: $market,
+            limit: $limit,
+            offset: $offset,
+            includeExternal: $includeExternal
+        );
+    }
+}

--- a/src/Resources/SearchResource.php
+++ b/src/Resources/SearchResource.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jordanpartridge\SpotifyClient\Resources;
+
+use Jordanpartridge\SpotifyClient\Requests\Search\SearchAlbumsRequest;
+use Jordanpartridge\SpotifyClient\Requests\Search\SearchAllRequest;
+use Jordanpartridge\SpotifyClient\Requests\Search\SearchArtistsRequest;
+use Jordanpartridge\SpotifyClient\Requests\Search\SearchPlaylistsRequest;
+use Jordanpartridge\SpotifyClient\Requests\Search\SearchRequest;
+use Jordanpartridge\SpotifyClient\Requests\Search\SearchTracksRequest;
+use Saloon\Http\BaseResource;
+use Saloon\Http\Response;
+
+class SearchResource extends BaseResource
+{
+    private string $query = '';
+
+    private ?string $market = null;
+
+    private int $limit = 20;
+
+    private int $offset = 0;
+
+    private bool $includeExternal = false;
+
+    /**
+     * Set the search query.
+     */
+    public function query(string $query): self
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    /**
+     * Set the market (country code).
+     */
+    public function market(string $market): self
+    {
+        $this->market = $market;
+
+        return $this;
+    }
+
+    /**
+     * Set the number of results to return.
+     */
+    public function limit(int $limit): self
+    {
+        $this->limit = min(50, max(1, $limit)); // Spotify API limits: 1-50
+
+        return $this;
+    }
+
+    /**
+     * Set the offset for pagination.
+     */
+    public function offset(int $offset): self
+    {
+        $this->offset = max(0, $offset);
+
+        return $this;
+    }
+
+    /**
+     * Include external audio content.
+     */
+    public function includeExternal(bool $include = true): self
+    {
+        $this->includeExternal = $include;
+
+        return $this;
+    }
+
+    /**
+     * Search for tracks only.
+     */
+    public function tracks(?string $query = null): Response
+    {
+        $searchQuery = $query ?? $this->query;
+
+        return $this->connector->send(
+            new SearchTracksRequest(
+                $searchQuery,
+                $this->market,
+                $this->limit,
+                $this->offset,
+                $this->includeExternal
+            )
+        );
+    }
+
+    /**
+     * Search for albums only.
+     */
+    public function albums(?string $query = null): Response
+    {
+        $searchQuery = $query ?? $this->query;
+
+        return $this->connector->send(
+            new SearchAlbumsRequest(
+                $searchQuery,
+                $this->market,
+                $this->limit,
+                $this->offset,
+                $this->includeExternal
+            )
+        );
+    }
+
+    /**
+     * Search for artists only.
+     */
+    public function artists(?string $query = null): Response
+    {
+        $searchQuery = $query ?? $this->query;
+
+        return $this->connector->send(
+            new SearchArtistsRequest(
+                $searchQuery,
+                $this->market,
+                $this->limit,
+                $this->offset,
+                $this->includeExternal
+            )
+        );
+    }
+
+    /**
+     * Search for playlists only.
+     */
+    public function playlists(?string $query = null): Response
+    {
+        $searchQuery = $query ?? $this->query;
+
+        return $this->connector->send(
+            new SearchPlaylistsRequest(
+                $searchQuery,
+                $this->market,
+                $this->limit,
+                $this->offset,
+                $this->includeExternal
+            )
+        );
+    }
+
+    /**
+     * Search across all content types.
+     */
+    public function all(?string $query = null): Response
+    {
+        $searchQuery = $query ?? $this->query;
+
+        return $this->connector->send(
+            new SearchAllRequest(
+                $searchQuery,
+                $this->market,
+                $this->limit,
+                $this->offset,
+                $this->includeExternal
+            )
+        );
+    }
+
+    /**
+     * Search with custom types.
+     */
+    public function custom(array $types, ?string $query = null): Response
+    {
+        $searchQuery = $query ?? $this->query;
+
+        return $this->connector->send(
+            new SearchRequest(
+                $searchQuery,
+                $types,
+                $this->market,
+                $this->limit,
+                $this->offset,
+                $this->includeExternal
+            )
+        );
+    }
+
+    /**
+     * Quick search for the most relevant track.
+     */
+    public function firstTrack(string $query): ?array
+    {
+        $response = $this->limit(1)->tracks($query);
+        $data = $response->json();
+
+        return $data['tracks']['items'][0] ?? null;
+    }
+
+    /**
+     * Search and get playable URI for first result.
+     */
+    public function getFirstTrackUri(string $query): ?string
+    {
+        $track = $this->firstTrack($query);
+
+        return $track['uri'] ?? null;
+    }
+}

--- a/src/SpotifyClient.php
+++ b/src/SpotifyClient.php
@@ -9,6 +9,7 @@ use Jordanpartridge\SpotifyClient\Resources\AlbumsResource;
 use Jordanpartridge\SpotifyClient\Resources\ArtistsResource;
 use Jordanpartridge\SpotifyClient\Resources\PlayerResource;
 use Jordanpartridge\SpotifyClient\Resources\PlaylistsResource;
+use Jordanpartridge\SpotifyClient\Resources\SearchResource;
 use Jordanpartridge\SpotifyClient\Resources\TracksResource;
 use Jordanpartridge\SpotifyClient\Resources\UsersResource;
 
@@ -46,5 +47,10 @@ class SpotifyClient implements SpotifyClientInterface
     public function player(): PlayerResource
     {
         return $this->connector->player();
+    }
+
+    public function search(): SearchResource
+    {
+        return $this->connector->search();
     }
 }

--- a/src/SpotifyConnector.php
+++ b/src/SpotifyConnector.php
@@ -8,6 +8,7 @@ use Jordanpartridge\SpotifyClient\Resources\AlbumsResource;
 use Jordanpartridge\SpotifyClient\Resources\ArtistsResource;
 use Jordanpartridge\SpotifyClient\Resources\PlayerResource;
 use Jordanpartridge\SpotifyClient\Resources\PlaylistsResource;
+use Jordanpartridge\SpotifyClient\Resources\SearchResource;
 use Jordanpartridge\SpotifyClient\Resources\TracksResource;
 use Jordanpartridge\SpotifyClient\Resources\UsersResource;
 use Saloon\Http\Connector;
@@ -60,5 +61,10 @@ class SpotifyConnector extends Connector
     public function player(): PlayerResource
     {
         return new PlayerResource($this);
+    }
+
+    public function search(): SearchResource
+    {
+        return new SearchResource($this);
     }
 }


### PR DESCRIPTION
## Summary
- Implements comprehensive search functionality for the Spotify Web API
- Adds SearchResource with 6 search methods: searchAll(), searchTracks(), searchAlbums(), searchArtists(), searchPlaylists(), and search()
- Clean implementation without merge conflicts

## Features Added
- `SearchResource` with comprehensive search capabilities
- `SearchAllRequest` for multi-type search across all content types
- `SearchTracksRequest` for track-specific searches
- `SearchAlbumsRequest` for album-specific searches  
- `SearchArtistsRequest` for artist-specific searches
- `SearchPlaylistsRequest` for playlist-specific searches
- `SearchRequest` base implementation for custom searches
- Updated `SpotifyConnector`, `SpotifyClient`, and `SpotifyClientInterface` to include search functionality

## Implementation Details
- Follows established Saloon request/resource patterns
- Supports all Spotify search parameters (q, type, market, limit, offset, include_external)
- Maintains type safety with proper return types
- Includes comprehensive PHPDoc documentation

🤖 Generated with [Claude Code](https://claude.ai/code)